### PR TITLE
Simplify use of converters with standard XSD date/time types.

### DIFF
--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/DurationXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/DurationXmlAdapter.java
@@ -11,6 +11,8 @@ import java.time.Duration;
  * <li>{@link java.time.Duration#parse(java.lang.CharSequence)}</li>
  * <li>{@link java.time.Duration#toString()}</li>
  * </ul>
+ * <p>
+ * This adapter is suitable for {@code xsd:duration} types.
  *
  * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
  * @see java.time.Duration

--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/IntegerAsTextXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/IntegerAsTextXmlAdapter.java
@@ -1,0 +1,22 @@
+package io.github.threetenjaxb.core;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+
+/**
+ * {@code XmlAdapter} mapping an integer as a string value
+ * <p>
+ * This adapter is suitable for {@code xsd:gDay} types.
+ *
+ * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
+ */
+public class IntegerAsTextXmlAdapter extends XmlAdapter<String, Integer> {
+    @Override
+    public Integer unmarshal(String stringValue) {
+        return stringValue != null ? Integer.parseInt(stringValue) : null;
+    }
+
+    @Override
+    public String marshal(Integer value) {
+        return value != null ? value.toString() : null;
+    }
+}

--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/LocalDateXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/LocalDateXmlAdapter.java
@@ -8,6 +8,8 @@ import java.time.format.DateTimeFormatter;
  * <p>
  * It uses {@link java.time.format.DateTimeFormatter#ISO_DATE} for parsing and serializing,
  * time-zone information ignored.
+ * <p>
+ * This adapter is suitable for {@code xsd:date} types.
  *
  * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
  * @see java.time.LocalDate

--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/MonthAsTextXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/MonthAsTextXmlAdapter.java
@@ -1,0 +1,31 @@
+package io.github.threetenjaxb.core;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+
+import java.time.Month;
+
+/**
+ * {@code XmlAdapter} mapping JSR-310 {@code Month} to ISO proleptic month string
+ * <p>
+ * Month string interpretation details (transformed to a string):
+ * <ul>
+ * <li>{@link java.time.Month#of(int)}</li>
+ * <li>{@link java.time.Month#getValue()}</li>
+ * </ul>
+ * <p>
+ * This adapter is suitable for {@code xsd:gMonth} types.
+ *
+ * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
+ * @see java.time.Month
+ */
+public class MonthAsTextXmlAdapter extends XmlAdapter<String, Month> {
+    @Override
+    public Month unmarshal(String stringValue) {
+        return stringValue != null ? Month.of(Integer.parseInt(stringValue)) : null;
+    }
+
+    @Override
+    public String marshal(Month value) {
+        return value != null ? Integer.toString(value.getValue()) : null;
+    }
+}

--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/MonthDayXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/MonthDayXmlAdapter.java
@@ -11,6 +11,8 @@ import jakarta.xml.bind.annotation.adapters.XmlAdapter;
  * <li>{@link java.time.MonthDay#parse(java.lang.CharSequence)}</li>
  * <li>{@link java.time.MonthDay#toString()}</li>
  * </ul>
+ * <p>
+ * This adapter is suitable for {@code xsd:gMonthDay} types.
  *
  * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
  * @see java.time.MonthDay

--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/MonthXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/MonthXmlAdapter.java
@@ -1,0 +1,32 @@
+package io.github.threetenjaxb.core;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+
+import java.time.Month;
+
+/**
+ * {@code XmlAdapter} mapping JSR-310 {@code Month} to ISO proleptic month number
+ * <p>
+ * Month number interpretation details:
+ * <ul>
+ * <li>{@link java.time.Month#of(int)}</li>
+ * <li>{@link java.time.Month#getValue()}</li>
+ * </ul>
+ * <p>
+ * Be aware that using this adapter will yield {@code null} when unmarshalling
+ * {@code xsd:gMonth} types. Use {@link MonthAsTextXmlAdapter} instead.
+ *
+ * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
+ * @see java.time.Month
+ */
+public class MonthXmlAdapter extends XmlAdapter<Integer, Month> {
+    @Override
+    public Month unmarshal(Integer intValue) {
+        return intValue != null ? Month.of(intValue) : null;
+    }
+
+    @Override
+    public Integer marshal(Month value) {
+        return value != null ? value.getValue() : null;
+    }
+}

--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/OffsetDateTimeXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/OffsetDateTimeXmlAdapter.java
@@ -7,6 +7,8 @@ import java.time.format.DateTimeFormatter;
  * {@code XmlAdapter} mapping JSR-310 {@code OffsetDateTime} to ISO-8601 string
  * <p>
  * String format details: {@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME}
+ * <p>
+ * This adapter is suitable for {@code xsd:dateTime} types.
  *
  * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
  * @see java.time.OffsetDateTime

--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/OffsetTimeXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/OffsetTimeXmlAdapter.java
@@ -7,6 +7,8 @@ import java.time.format.DateTimeFormatter;
  * {@code XmlAdapter} mapping JSR-310 {@code OffsetTime} to ISO-8601 string
  * <p>
  * String format details: {@link java.time.format.DateTimeFormatter#ISO_OFFSET_TIME}
+ * <p>
+ * This adapter is suitable for {@code xsd:time} types.
  *
  * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
  * @see java.time.OffsetTime

--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/YearAsTextXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/YearAsTextXmlAdapter.java
@@ -1,0 +1,31 @@
+package io.github.threetenjaxb.core;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+
+import java.time.Year;
+
+/**
+ * {@code XmlAdapter} mapping JSR-310 {@code Year} to ISO proleptic year string
+ * <p>
+ * Year string interpretation details:
+ * <ul>
+ * <li>{@link Year#parse(CharSequence)}</li>
+ * <li>{@link Year#toString()}</li>
+ * </ul>
+ * <p>
+ * This adapter is suitable for {@code xsd:gYear} types.
+ *
+ * @see XmlAdapter
+ * @see Year
+ */
+public class YearAsTextXmlAdapter extends XmlAdapter<String, Year> {
+    @Override
+    public Year unmarshal(String isoYearString) {
+        return isoYearString != null ? Year.parse(isoYearString) : null;
+    }
+
+    @Override
+    public String marshal(Year year) {
+        return year != null ? year.toString() : null;
+    }
+}

--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/YearMonthXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/YearMonthXmlAdapter.java
@@ -11,6 +11,8 @@ import jakarta.xml.bind.annotation.adapters.XmlAdapter;
  * <li>{@link java.time.YearMonth#parse(java.lang.CharSequence)}</li>
  * <li>{@link java.time.YearMonth#toString()}</li>
  * </ul>
+ * <p>
+ * This adapter is suitable for {@code xsd:gYearMonth} types.
  *
  * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
  * @see java.time.YearMonth

--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/YearXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/YearXmlAdapter.java
@@ -11,6 +11,9 @@ import jakarta.xml.bind.annotation.adapters.XmlAdapter;
  * <li>{@link java.time.Year#of(int)}</li>
  * <li>{@link java.time.Year#getValue()}</li>
  * </ul>
+ * <p>
+ * Be aware that using this adapter will yield {@code null} when unmarshalling
+ * {@code xsd:gYear} types. Use {@link YearAsTextXmlAdapter} instead.
  *
  * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
  * @see java.time.Year

--- a/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/IntegerAsTextXmlAdapterTest.java
+++ b/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/IntegerAsTextXmlAdapterTest.java
@@ -1,0 +1,17 @@
+package io.github.threetenjaxb.core;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class IntegerAsTextXmlAdapterTest extends AbstractXmlAdapterTest<String, Integer, IntegerAsTextXmlAdapter> {
+
+    private static final Map<String, Integer> STRING_INTEGER_MAP = new HashMap<>();
+
+    static {
+        STRING_INTEGER_MAP.put("1", 1);
+    }
+
+    IntegerAsTextXmlAdapterTest() {
+        super(new IntegerAsTextXmlAdapter(), STRING_INTEGER_MAP);
+    }
+}

--- a/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/MonthAsTextXmlAdapterTest.java
+++ b/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/MonthAsTextXmlAdapterTest.java
@@ -1,0 +1,18 @@
+package io.github.threetenjaxb.core;
+
+import java.time.Month;
+import java.util.HashMap;
+import java.util.Map;
+
+class MonthAsTextXmlAdapterTest extends AbstractXmlAdapterTest<String, Month, MonthAsTextXmlAdapter> {
+
+    private static final Map<String, Month> STRING_MONTH_MAP = new HashMap<>();
+
+    static {
+        STRING_MONTH_MAP.put("1", Month.of(1));
+    }
+
+    MonthAsTextXmlAdapterTest() {
+        super(new MonthAsTextXmlAdapter(), STRING_MONTH_MAP);
+    }
+}

--- a/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/MonthXmlAdapterTest.java
+++ b/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/MonthXmlAdapterTest.java
@@ -1,0 +1,19 @@
+package io.github.threetenjaxb.core;
+
+import java.time.Month;
+import java.time.Year;
+import java.util.HashMap;
+import java.util.Map;
+
+class MonthXmlAdapterTest extends AbstractXmlAdapterTest<Integer, Month, MonthXmlAdapter> {
+
+    private static final Map<Integer, Month> INTEGER_MONTH_MAP = new HashMap<>();
+
+    static {
+        INTEGER_MONTH_MAP.put(1, Month.of(1));
+    }
+
+    MonthXmlAdapterTest() {
+        super(new MonthXmlAdapter(), INTEGER_MONTH_MAP);
+    }
+}

--- a/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/YearAsTextXmlAdapterTest.java
+++ b/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/YearAsTextXmlAdapterTest.java
@@ -1,0 +1,18 @@
+package io.github.threetenjaxb.core;
+
+import java.time.Year;
+import java.util.HashMap;
+import java.util.Map;
+
+class YearAsTextXmlAdapterTest extends AbstractXmlAdapterTest<String, Year, YearAsTextXmlAdapter> {
+
+    private static final Map<String, Year> STRING_YEAR_MAP = new HashMap<>();
+
+    static {
+        STRING_YEAR_MAP.put("2007", Year.of(2007));
+    }
+
+    YearAsTextXmlAdapterTest() {
+        super(new YearAsTextXmlAdapter(), STRING_YEAR_MAP);
+    }
+}

--- a/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/integration/XmlAdaptersTest.java
+++ b/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/integration/XmlAdaptersTest.java
@@ -2,17 +2,23 @@ package io.github.threetenjaxb.core.integration;
 
 import io.github.threetenjaxb.core.DurationXmlAdapter;
 import io.github.threetenjaxb.core.InstantXmlAdapter;
+import io.github.threetenjaxb.core.IntegerAsTextXmlAdapter;
 import io.github.threetenjaxb.core.LocalDateTimeXmlAdapter;
 import io.github.threetenjaxb.core.LocalDateXmlAdapter;
 import io.github.threetenjaxb.core.LocalTimeXmlAdapter;
+import io.github.threetenjaxb.core.MonthAsTextXmlAdapter;
+import io.github.threetenjaxb.core.MonthXmlAdapter;
 import io.github.threetenjaxb.core.MonthDayXmlAdapter;
 import io.github.threetenjaxb.core.OffsetDateTimeXmlAdapter;
 import io.github.threetenjaxb.core.OffsetTimeXmlAdapter;
 import io.github.threetenjaxb.core.PeriodXmlAdapter;
+import io.github.threetenjaxb.core.YearAsTextXmlAdapter;
 import io.github.threetenjaxb.core.YearMonthXmlAdapter;
 import io.github.threetenjaxb.core.YearXmlAdapter;
 import io.github.threetenjaxb.core.ZoneIdXmlAdapter;
 import io.github.threetenjaxb.core.ZonedDateTimeXmlAdapter;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
 import org.junit.jupiter.api.Test;
 
 import jakarta.xml.bind.JAXBContext;
@@ -55,12 +61,15 @@ class XmlAdaptersTest {
         jaxbContext = JAXBContext.newInstance(Bean.class);
 
         final Bean expectedBean = new Bean();
+        expectedBean.dayTextified = 1;
         expectedBean.duration = Duration.ofDays(2).plusHours(3).plusMinutes(4);
         expectedBean.instant = LocalDateTime.of(2007, 12, 3, 10, 15, 30)
                 .toInstant(ZoneOffset.UTC);
         expectedBean.localDateTime = LocalDateTime.of(2007, 12, 3, 10, 15, 30);
         expectedBean.localDate = LocalDate.of(2014, 12, 31);
         expectedBean.localTime = LocalTime.of(10, 15, 30);
+        expectedBean.month = Month.DECEMBER;
+        expectedBean.monthTextified = Month.DECEMBER;
         expectedBean.monthDay = MonthDay.of(Month.DECEMBER, 3);
         expectedBean.offsetDateTime = OffsetDateTime
                 .of(2007, 12, 3, 10, 15, 30, 0, ZoneOffset.ofHours(1));
@@ -68,6 +77,7 @@ class XmlAdaptersTest {
                 .of(10, 15, 30, 0, ZoneOffset.ofHours(1));
         expectedBean.period = Period.of(1, 2, 25);
         expectedBean.year = Year.of(-2014);
+        expectedBean.yearTextified = Year.of(-2014);
         expectedBean.yearMonth = YearMonth.of(2014, 12);
         expectedBean.zoneId = ZoneId.of("America/New_York");
         expectedBean.zoneOffset = ZoneOffset.ofHoursMinutes(-12, 0);
@@ -95,16 +105,20 @@ class XmlAdaptersTest {
         final Bean bean = (Bean) unmarshaller.unmarshal(expectedMarshalledBean);
 
         assertAll("bean",
+                () -> assertEquals(expectedBean.dayTextified, bean.dayTextified),
                 () -> assertEquals(expectedBean.duration, bean.duration),
                 () -> assertEquals(expectedBean.instant, bean.instant),
                 () -> assertEquals(expectedBean.localDateTime, bean.localDateTime),
                 () -> assertEquals(expectedBean.localDate, bean.localDate),
                 () -> assertEquals(expectedBean.localTime, bean.localTime),
+                () -> assertEquals(expectedBean.month, bean.month),
+                () -> assertEquals(expectedBean.monthTextified, bean.monthTextified),
                 () -> assertEquals(expectedBean.monthDay, bean.monthDay),
                 () -> assertEquals(expectedBean.offsetDateTime, bean.offsetDateTime),
                 () -> assertEquals(expectedBean.offsetTime, bean.offsetTime),
                 () -> assertEquals(expectedBean.period, bean.period),
                 () -> assertEquals(expectedBean.year, bean.year),
+                () -> assertEquals(expectedBean.yearTextified, bean.yearTextified),
                 () -> assertEquals(expectedBean.yearMonth, bean.yearMonth),
                 () -> assertEquals(expectedBean.zoneId, bean.zoneId),
                 () -> assertEquals(expectedBean.zoneOffset, bean.zoneOffset),
@@ -114,7 +128,14 @@ class XmlAdaptersTest {
 
     @XmlRootElement
     static class Bean {
+
+        @XmlJavaTypeAdapter(IntegerAsTextXmlAdapter.class)
+        @XmlSchemaType(name = "gDay")
+        @XmlElement(type = String.class)
+        Integer dayTextified;
+
         @XmlJavaTypeAdapter(DurationXmlAdapter.class)
+        @XmlSchemaType(name = "duration")
         Duration duration;
 
         @XmlJavaTypeAdapter(InstantXmlAdapter.class)
@@ -124,18 +145,30 @@ class XmlAdaptersTest {
         LocalDateTime localDateTime;
 
         @XmlJavaTypeAdapter(LocalDateXmlAdapter.class)
+        @XmlSchemaType(name = "date")
         LocalDate localDate;
 
         @XmlJavaTypeAdapter(LocalTimeXmlAdapter.class)
         LocalTime localTime;
 
+        @XmlJavaTypeAdapter(MonthXmlAdapter.class)
+        Month month;
+
+        @XmlJavaTypeAdapter(MonthAsTextXmlAdapter.class)
+        @XmlSchemaType(name = "gMonth")
+        @XmlElement(type = String.class)
+        Month monthTextified;
+
         @XmlJavaTypeAdapter(MonthDayXmlAdapter.class)
+        @XmlSchemaType(name = "gMonthDay")
         MonthDay monthDay;
 
         @XmlJavaTypeAdapter(OffsetDateTimeXmlAdapter.class)
+        @XmlSchemaType(name = "dateTime")
         OffsetDateTime offsetDateTime;
 
         @XmlJavaTypeAdapter(OffsetTimeXmlAdapter.class)
+        @XmlSchemaType(name = "time")
         OffsetTime offsetTime;
 
         @XmlJavaTypeAdapter(PeriodXmlAdapter.class)
@@ -144,7 +177,13 @@ class XmlAdaptersTest {
         @XmlJavaTypeAdapter(YearXmlAdapter.class)
         Year year;
 
+        @XmlJavaTypeAdapter(YearAsTextXmlAdapter.class)
+        @XmlSchemaType(name = "gYear")
+        @XmlElement(type = String.class)
+        Year yearTextified;
+
         @XmlJavaTypeAdapter(YearMonthXmlAdapter.class)
+        @XmlSchemaType(name = "gYearMonth")
         YearMonth yearMonth;
 
         @XmlJavaTypeAdapter(ZoneIdXmlAdapter.class)

--- a/threeten-jaxb-core/src/test/resources/io/github/threetenjaxb/core/integration/expectedBean.xml
+++ b/threeten-jaxb-core/src/test/resources/io/github/threetenjaxb/core/integration/expectedBean.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <bean>
+    <dayTextified>1</dayTextified>
     <duration>PT51H4M</duration>
     <instant>2007-12-03T10:15:30Z</instant>
     <localDateTime>2007-12-03T10:15:30</localDateTime>
     <localDate>2014-12-31</localDate>
     <localTime>10:15:30</localTime>
+    <month>12</month>
+    <monthTextified>12</monthTextified>
     <monthDay>--12-03</monthDay>
     <offsetDateTime>2007-12-03T10:15:30+01:00</offsetDateTime>
     <offsetTime>10:15:30+01:00</offsetTime>
     <period>P1Y2M25D</period>
     <year>-2014</year>
+    <yearTextified>-2014</yearTextified>
     <yearMonth>2014-12</yearMonth>
     <zoneId>America/New_York</zoneId>
     <zoneOffset>-12:00</zoneOffset>

--- a/threeten-jaxb-extra/src/main/java/io/github/threetenjaxb/extra/DayOfMonthAsTextXmlAdapter.java
+++ b/threeten-jaxb-extra/src/main/java/io/github/threetenjaxb/extra/DayOfMonthAsTextXmlAdapter.java
@@ -1,0 +1,24 @@
+package io.github.threetenjaxb.extra;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import org.threeten.extra.DayOfMonth;
+
+/**
+ * {@link XmlAdapter} for {@link DayOfMonth}
+ *
+ * <p>This {@link XmlAdapter} binds {@link DayOfMonth} to its day-of-month
+ * value.
+ * <p>
+ * This adapter is suitable for {@code xsd:gDay} types.
+ */
+public class DayOfMonthAsTextXmlAdapter extends XmlAdapter<String, DayOfMonth> {
+    @Override
+    public DayOfMonth unmarshal(String text) {
+        return text != null ? DayOfMonth.of(Integer.parseInt(text)) : null;
+    }
+
+    @Override
+    public String marshal(DayOfMonth dayOfMonth) {
+        return dayOfMonth != null ? Integer.toString(dayOfMonth.getValue()) : null;
+    }
+}

--- a/threeten-jaxb-extra/src/main/java/io/github/threetenjaxb/extra/DayOfMonthXmlAdapter.java
+++ b/threeten-jaxb-extra/src/main/java/io/github/threetenjaxb/extra/DayOfMonthXmlAdapter.java
@@ -9,6 +9,9 @@ import jakarta.xml.bind.annotation.adapters.XmlAdapter;
  *
  * <p>This {@link XmlAdapter} binds {@link DayOfMonth} to its day-of-month
  * value.
+ * <p>
+ * Be aware that using this adapter will yield {@code null} when unmarshalling
+ * {@code xsd:gDay} types. Use {@link DayOfMonthAsTextXmlAdapter} instead.
  */
 public class DayOfMonthXmlAdapter extends XmlAdapter<Integer, DayOfMonth> {
     @Override

--- a/threeten-jaxb-extra/src/test/java/io/github/threetenjaxb/extra/DayOfMonthAsTextXmlAdapterTest.java
+++ b/threeten-jaxb-extra/src/test/java/io/github/threetenjaxb/extra/DayOfMonthAsTextXmlAdapterTest.java
@@ -1,0 +1,19 @@
+package io.github.threetenjaxb.extra;
+
+import org.threeten.extra.DayOfMonth;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class DayOfMonthAsTextXmlAdapterTest extends AbstractXmlAdapterTest<String, DayOfMonth, DayOfMonthAsTextXmlAdapter> {
+
+    private static final Map<String, DayOfMonth> STRING_DAY_OF_MONTH_MAP = new HashMap<>();
+
+    static {
+        STRING_DAY_OF_MONTH_MAP.put("21", DayOfMonth.of(21));
+    }
+
+    DayOfMonthAsTextXmlAdapterTest() {
+        super(new DayOfMonthAsTextXmlAdapter(), STRING_DAY_OF_MONTH_MAP);
+    }
+}

--- a/threeten-jaxb-extra/src/test/java/io/github/threetenjaxb/extra/integration/XmlAdaptersTest.java
+++ b/threeten-jaxb-extra/src/test/java/io/github/threetenjaxb/extra/integration/XmlAdaptersTest.java
@@ -1,5 +1,6 @@
 package io.github.threetenjaxb.extra.integration;
 
+import io.github.threetenjaxb.extra.DayOfMonthAsTextXmlAdapter;
 import io.github.threetenjaxb.extra.DayOfMonthXmlAdapter;
 import io.github.threetenjaxb.extra.DayOfYearXmlAdapter;
 import io.github.threetenjaxb.extra.DaysXmlAdapter;
@@ -14,6 +15,8 @@ import io.github.threetenjaxb.extra.WeeksXmlAdapter;
 import io.github.threetenjaxb.extra.YearQuarterXmlAdapter;
 import io.github.threetenjaxb.extra.YearWeekXmlAdapter;
 import io.github.threetenjaxb.extra.YearsXmlAdapter;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
 import org.junit.jupiter.api.Test;
 import org.threeten.extra.DayOfMonth;
 import org.threeten.extra.DayOfYear;
@@ -63,6 +66,7 @@ class XmlAdaptersTest {
 
         final Bean expectedBean = new Bean();
         expectedBean.dayOfMonth = DayOfMonth.of(21);
+        expectedBean.dayOfMonthTextified = DayOfMonth.of(21);
         expectedBean.dayOfYear = DayOfYear.of(51);
         expectedBean.days = Days.of(12);
         expectedBean.hours = Hours.of(4);
@@ -106,6 +110,7 @@ class XmlAdaptersTest {
         final Bean unmarshalled = (Bean) unmarshaller.unmarshal(expectedMarshalledBean);
         assertAll("bean",
                 () -> assertEquals(expectedBean.dayOfMonth, unmarshalled.dayOfMonth),
+                () -> assertEquals(expectedBean.dayOfMonthTextified, unmarshalled.dayOfMonthTextified),
                 () -> assertEquals(expectedBean.dayOfYear, unmarshalled.dayOfYear),
                 () -> assertEquals(expectedBean.days, unmarshalled.days),
                 () -> assertEquals(expectedBean.hours, unmarshalled.hours),
@@ -126,6 +131,11 @@ class XmlAdaptersTest {
     static class Bean {
         @XmlJavaTypeAdapter(DayOfMonthXmlAdapter.class)
         DayOfMonth dayOfMonth;
+
+        @XmlJavaTypeAdapter(DayOfMonthAsTextXmlAdapter.class)
+        @XmlSchemaType(name = "gDay")
+        @XmlElement(type = String.class)
+        DayOfMonth dayOfMonthTextified;
 
         @XmlJavaTypeAdapter(DayOfYearXmlAdapter.class)
         DayOfYear dayOfYear;

--- a/threeten-jaxb-extra/src/test/resources/io/github/threetenjaxb/extra/integration/expectedBean.xml
+++ b/threeten-jaxb-extra/src/test/resources/io/github/threetenjaxb/extra/integration/expectedBean.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <bean>
     <dayOfMonth>21</dayOfMonth>
+    <dayOfMonthTextified>21</dayOfMonthTextified>
     <dayOfYear>51</dayOfYear>
     <days>P12D</days>
     <hours>PT4H</hours>


### PR DESCRIPTION
Add converter for java.time.Month and textifying converters. Add description of what official XSD date/time type correctly maps with which converter.