### PR TITLE
Add adapters that can handle xsd:dateTime and xsd:time that are capable of handling time in both local and offset representation.

### DIFF
--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/LenientOffsetDateTimeXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/LenientOffsetDateTimeXmlAdapter.java
@@ -1,0 +1,37 @@
+package io.github.threetenjaxb.core;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+/**
+ * {@code XmlAdapter} mapping JSR-310 {@code OffsetDateTime} to ISO-8601 string that can also
+ * parse local date time representations as UTC
+ * <p>
+ * String format details: {@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME}
+ * <p>
+ * This adapter is suitable for {@code xsd:dateTime} types.
+ *
+ * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
+ * @see java.time.OffsetDateTime
+ */
+public class LenientOffsetDateTimeXmlAdapter extends TemporalAccessorXmlAdapter<OffsetDateTime> {
+    public LenientOffsetDateTimeXmlAdapter() {
+        super(new DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                .parseLenient()
+                .optionalStart()
+                .appendOffsetId()
+                .toFormatter(), value -> {
+            if (value.isSupported(ChronoField.OFFSET_SECONDS)) {
+                return OffsetDateTime.from(value);
+            } else {
+                return LocalDateTime.from(value).atOffset(ZoneOffset.UTC);
+            }
+        });
+    }
+}

--- a/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/LenientOffsetTimeXmlAdapter.java
+++ b/threeten-jaxb-core/src/main/java/io/github/threetenjaxb/core/LenientOffsetTimeXmlAdapter.java
@@ -1,0 +1,36 @@
+package io.github.threetenjaxb.core;
+
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+/**
+ * {@code XmlAdapter} mapping JSR-310 {@code OffsetTime} to ISO-8601 string that can also
+ * parse local time representations as UTC
+ * <p>
+ * String format details: {@link DateTimeFormatter#ISO_OFFSET_TIME}
+ * <p>
+ * This adapter is suitable for {@code xsd:time} types.
+ *
+ * @see jakarta.xml.bind.annotation.adapters.XmlAdapter
+ * @see OffsetTime
+ */
+public class LenientOffsetTimeXmlAdapter extends TemporalAccessorXmlAdapter<OffsetTime> {
+    public LenientOffsetTimeXmlAdapter() {
+        super(new DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .append(DateTimeFormatter.ISO_LOCAL_TIME)
+                .optionalStart()
+                .appendOffsetId()
+                .toFormatter(), value -> {
+            if (value.isSupported(ChronoField.OFFSET_SECONDS)) {
+                return OffsetTime.from(value);
+            } else {
+                return LocalTime.from(value).atOffset(ZoneOffset.UTC);
+            }
+        });
+    }
+}

--- a/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/AbstractXmlAdapterTest.java
+++ b/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/AbstractXmlAdapterTest.java
@@ -11,8 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 abstract class AbstractXmlAdapterTest<ValueType, BoundType, XmlAdapterType extends XmlAdapter<ValueType, BoundType>> {
 
-    private final XmlAdapterType xmlAdapterType;
-    private final Map<ValueType, BoundType> valueBoundMap;
+    final XmlAdapterType xmlAdapterType;
+    final Map<ValueType, BoundType> valueBoundMap;
 
     AbstractXmlAdapterTest(final XmlAdapterType xmlAdapterType, final Map<ValueType, BoundType> valueBoundMap) {
         this.xmlAdapterType = Objects.requireNonNull(xmlAdapterType, "xmlAdapterType must not be null");

--- a/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/LenientOffsetDateTimeXmlAdapterTest.java
+++ b/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/LenientOffsetDateTimeXmlAdapterTest.java
@@ -1,0 +1,48 @@
+package io.github.threetenjaxb.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LenientOffsetDateTimeXmlAdapterTest extends AbstractXmlAdapterTest<String, OffsetDateTime, LenientOffsetDateTimeXmlAdapter> {
+
+    private static final Map<String, OffsetDateTime> STRING_OFFSET_DATE_TIME_MAP = new HashMap<>();
+
+    static {
+        STRING_OFFSET_DATE_TIME_MAP.put("2007-12-03T10:15:30+01:00",
+                OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 0,
+                        ZoneOffset.ofHours(1))
+        );
+        STRING_OFFSET_DATE_TIME_MAP.put("2007-12-03T10:15:30Z",
+                OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 0,
+                        ZoneOffset.UTC)
+        );
+        STRING_OFFSET_DATE_TIME_MAP.put("2007-12-03T10:15:30.00000005+01:00",
+                OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 50,
+                        ZoneOffset.ofHours(1))
+        );
+    }
+
+    LenientOffsetDateTimeXmlAdapterTest() {
+        super(new LenientOffsetDateTimeXmlAdapter(), STRING_OFFSET_DATE_TIME_MAP);
+    }
+
+    @Test
+    void unmarshalLocalDateTime() {
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 0,
+                ZoneOffset.UTC);
+        assertEquals(offsetDateTime, xmlAdapterType.unmarshal("2007-12-03T10:15:30"));
+    }
+
+    @Test
+    void unmarshalUTC() {
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 0,
+                ZoneOffset.UTC);
+        assertEquals(offsetDateTime, xmlAdapterType.unmarshal("2007-12-03T10:15:30Z"));
+    }
+}

--- a/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/LenientOffsetTimeXmlAdapterTest.java
+++ b/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/LenientOffsetTimeXmlAdapterTest.java
@@ -1,0 +1,42 @@
+package io.github.threetenjaxb.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LenientOffsetTimeXmlAdapterTest extends AbstractXmlAdapterTest<String, OffsetTime, LenientOffsetTimeXmlAdapter> {
+
+    private static final Map<String, OffsetTime> STRING_OFFSET_TIME_MAP = new HashMap<>();
+
+    static {
+        STRING_OFFSET_TIME_MAP.put("10:15:30+01:00", OffsetTime
+                .of(10, 15, 30, 0, ZoneOffset.ofHours(1))
+        );
+        STRING_OFFSET_TIME_MAP.put("10:15:30.00000005+01:00", OffsetTime
+                .of(10, 15, 30, 50, ZoneOffset.ofHours(1))
+        );
+    }
+
+    LenientOffsetTimeXmlAdapterTest() {
+        super(new LenientOffsetTimeXmlAdapter(), STRING_OFFSET_TIME_MAP);
+    }
+
+    @Test
+    void unmarshalLocalTime() {
+        OffsetTime offsetTime = OffsetTime.of(10, 15, 30, 0, ZoneOffset.UTC);
+        assertEquals(offsetTime, xmlAdapterType.unmarshal("10:15:30"));
+    }
+
+    @Test
+    void unmarshalUTC() {
+        OffsetTime offsetTime = OffsetTime.of(10, 15, 30, 0, ZoneOffset.UTC);
+        assertEquals(offsetTime, xmlAdapterType.unmarshal("10:15:30Z"));
+    }
+}

--- a/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/OffsetDateTimeXmlAdapterTest.java
+++ b/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/OffsetDateTimeXmlAdapterTest.java
@@ -14,6 +14,14 @@ class OffsetDateTimeXmlAdapterTest extends AbstractXmlAdapterTest<String, Offset
                 OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 0,
                         ZoneOffset.ofHours(1))
         );
+        STRING_OFFSET_DATE_TIME_MAP.put("2007-12-03T10:15:30Z",
+                OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 0,
+                        ZoneOffset.UTC)
+        );
+        STRING_OFFSET_DATE_TIME_MAP.put("2007-12-03T10:15:30.00000005+01:00",
+                OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 50,
+                        ZoneOffset.ofHours(1))
+        );
     }
 
     OffsetDateTimeXmlAdapterTest() {

--- a/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/OffsetTimeXmlAdapterTest.java
+++ b/threeten-jaxb-core/src/test/java/io/github/threetenjaxb/core/OffsetTimeXmlAdapterTest.java
@@ -13,6 +13,12 @@ class OffsetTimeXmlAdapterTest extends AbstractXmlAdapterTest<String, OffsetTime
         STRING_OFFSET_TIME_MAP.put("10:15:30+01:00", OffsetTime
                 .of(10, 15, 30, 0, ZoneOffset.ofHours(1))
         );
+        STRING_OFFSET_TIME_MAP.put("10:15:30Z", OffsetTime
+                .of(10, 15, 30, 0, ZoneOffset.UTC)
+        );
+        STRING_OFFSET_TIME_MAP.put("10:15:30.00000005+01:00", OffsetTime
+                .of(10, 15, 30, 50, ZoneOffset.ofHours(1))
+        );
     }
 
     OffsetTimeXmlAdapterTest() {


### PR DESCRIPTION
The XML specification allows multiple representations of time (https://www.ibm.com/docs/sl/i/7.3?topic=types-xsdatetime) where the time zone is optional. At the same time, Java makes a clear distinction where the two formats are not interchangable. To support both formats for the same field, a lenient version of the Offset(Date)TimeAdapter allows for processing both formats where a missing offset is considered as UTC.